### PR TITLE
Hide NavigationBar

### DIFF
--- a/RMParallax/RMParallax/RMParallax.swift
+++ b/RMParallax/RMParallax/RMParallax.swift
@@ -74,6 +74,9 @@ class RMParallax : UIViewController, UIScrollViewDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // Hide the Navigation Bar if needed. 
+        self.parentViewController?.navigationController?.navigationBar.hidden = true
         self.setupRMParallax()
     }
     
@@ -154,6 +157,8 @@ class RMParallax : UIViewController, UIScrollViewDelegate {
     
     func closeButtonSelected(sender: UIButton) {
         self.completionHandler()
+        
+        self.parentViewController?.navigationController?.navigationBar.hidden = false
     }
     
     // MARK : UIScrollViewDelegate


### PR DESCRIPTION
If MainViewController is embedded in UINavigationController, then the PMParallax View would be weird, because the top bar will block the image. So, we should hide the navigationBar in viewDidLoad, and enable it after closing the PMParallax View.
Auto-layout of buttons and views should also be adjust to "View" rather than "Top Layout Guide".
